### PR TITLE
Add UriFactoryInterface.

### DIFF
--- a/src/DependencyInjection/AjgarlagPsrHttpMessageExtension.php
+++ b/src/DependencyInjection/AjgarlagPsrHttpMessageExtension.php
@@ -17,6 +17,7 @@ use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ServerRequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\UploadedFileFactoryInterface;
+use Psr\Http\Message\UriFactoryInterface;
 use Sensio\Bundle\FrameworkExtraBundle\DependencyInjection\Configuration as SensioFrameworkExtraConfiguration;
 use Sensio\Bundle\FrameworkExtraBundle\Request\ArgumentValueResolver\Psr7ServerRequestResolver;
 use Symfony\Component\Config\FileLocator;
@@ -83,6 +84,7 @@ class AjgarlagPsrHttpMessageExtension extends Extension implements CompilerPassI
             ServerRequestFactoryInterface::class,
             StreamFactoryInterface::class,
             UploadedFileFactoryInterface::class,
+            UriFactoryInterface::class,
         ];
 
         $nyholmPsr17Id = 'nyholm.psr7.psr17_factory';

--- a/src/Resources/config/psr7.xml
+++ b/src/Resources/config/psr7.xml
@@ -10,6 +10,7 @@
             <argument type="service" id="Psr\Http\Message\StreamFactoryInterface" />
             <argument type="service" id="Psr\Http\Message\UploadedFileFactoryInterface" />
             <argument type="service" id="Psr\Http\Message\ResponseFactoryInterface" />
+            <argument type="service" id="Psr\Http\Message\UriFactoryInterface" />
         </service>
         <service id="ajgarlag_psr_http_message.psr7.http_foundation_factory" class="Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory" />
 


### PR DESCRIPTION
Hello,

I'm in the process of upgrading a package: [ecphp/cas-bundle](https://github.com/ecphp/cas-bundle/) and I notice that sensio/framework-extra-bundle has removed support for PSR7.

While working with your bundle, I noticed that the `UriFactoryInterface` is missing from your package, and we need it.

This PR do the necessary wiring for that missing interface.